### PR TITLE
Corrected the LANDFIRE version selection logic

### DIFF
--- a/src/landfire/landfire.py
+++ b/src/landfire/landfire.py
@@ -4,6 +4,7 @@ import rasterio
 import requests
 import time
 import zipfile
+from datetime import datetime
 
 import util.general_util as gen_util
 import util.processing_util as proc_util
@@ -144,7 +145,7 @@ def split_tifs_in_zip(zip_path, fid):
                         dst.write(band_data, 1)
                         dst.set_band_description(1, band_name)
 
-def get_lf_layers_given_vars_and_year(var_names, year, state):
+def get_lf_layers_given_vars_and_start_time(var_names, start_time, state):
     """
     Get LANDFIRE layer name for the given variables based on the fire year and state.
 
@@ -156,9 +157,13 @@ def get_lf_layers_given_vars_and_year(var_names, year, state):
     Returns:
         list: List of LANDFIRE layer names (one for each given variable).
     """
-
     # Yearly cutpoints (one for each time LANDFIRE released a new version, based on most recent LANDFIRE reconfiguration)
-    year_cutpoints = [2016,2022,2023]
+    cutoffs = [
+        (datetime(2016, 12, 31), 2016),
+        (datetime(2022, 12, 31), 2022),
+        (datetime(2023, 10, 1), 2023),
+        (datetime(2024, 10, 1), 2024),
+    ]
     # Map of variables EVT/FBFM13/FBFM40 to layer names based on each yearly cutpoint
     version_lists = {
         'EVT': [str(num) + 'EVT' for num in [200,230,240]],
@@ -181,12 +186,13 @@ def get_lf_layers_given_vars_and_year(var_names, year, state):
         # EVT/FBFM13/FBFM40 have layer names as defined in maps above
         elif var in ['EVT', 'FBFM13', 'FBFM40']:
             versions = version_lists[var]
-            for ind in range(len(year_cutpoints)):
-                if year-1 <= year_cutpoints[ind]:
-                    layer_name = f'LF{year_cutpoints[ind]}_{var}' #versions[ind]
-                    break
-            else:
-                layer_name = latest_versions[var]
+            layer_name = None
+            for cutoff, year in cutoffs:
+                if start_time >= cutoff:
+                    layer_name = f'LF{year}_{var}' #versions[ind]
+            if layer_name is None:
+                #NOTE: pass error here if we want to strictly enforce the landfire version to precede the fire
+                layer_name = f'LF{2016}_{var}'
         # ROADS only has layer name 240ROADS_23 for CONUS
         # Currently, the supposed layer for Alaska/Hawaii is 220ROADS_20, but this doesn't work, so skip for now
         elif var in ['ROADS']:
@@ -218,7 +224,7 @@ def driver_landfire(fid, var_names, bounds, fire_start, plot_types=[]):
         RuntimeError: Occurs when LANDFIRE download failed.
     """
     # bounds should be in W,S,E,N format
-    layers = get_lf_layers_given_vars_and_year(var_names, int(fire_start.year), fid[:2])
+    layers = get_lf_layers_given_vars_and_start_time(var_names, fire_start, fid[:2])
     lf_zip_path = gen_util.get_lf_zip_filename(fid)
 
     download_success = download_landfire_data(

--- a/src/pyregence/pyregence.py
+++ b/src/pyregence/pyregence.py
@@ -5,6 +5,7 @@ import pyregence.fuel_wx_ign_pb2_grpc as fuel_wx_ign_pb2_grpc
 import rasterio
 import requests
 import tarfile
+from datetime import datetime
 
 import util.general_util as gen_util
 import util.processing_util as proc_util
@@ -41,24 +42,18 @@ def get_landfire_version(start_time):
     Returns:
         str: LANDFIRE version for the given start time/year.
     """
-    # Landfire versioninig based on this naming guide: https://www.landfire.gov/LFNameConvention
-    year = start_time.year
-    lf_year_for_fire = year - 1
-    lf_year_to_version_map = {
-        2024 : '2.5.0',
-        2023 : '2.4.0',
-        2022 : '2.3.0',
-        2020 : '2.2.0',
-        2016 : '2.0.0',
-        2014 : '1.4.0'
-    }
-    version_to_use = None
-    for lf_base_year in lf_year_to_version_map:
-        if lf_year_for_fire <= lf_base_year:
-            version_to_use = lf_year_to_version_map[lf_base_year]
-    if version_to_use is None:
-        raise ValueError(f'No valid LANDFIRE mapping for given year {year} (with LF year {lf_year_for_fire})')
-    return version_to_use
+    # Landfire versioning based on this naming guide: https://www.landfire.gov/LFNameConvention
+    cutoffs = [
+        (datetime(2024, 10, 1),  '2.5.0'),
+        (datetime(2023, 10, 1),  '2.4.0'),
+        (datetime(2022, 12, 31), '2.3.0'),
+        (datetime(2020, 12, 31), '2.2.0'),
+        (datetime(2016, 12, 31), '2.0.0'),
+    ]
+    for cutoff_date, version in cutoffs:
+        if start_time > cutoff_date:
+            return version
+    return '1.4.0'
 
 def download_pyregence_data(
         out_dir, out_file, center, buffer=(60,60,60,60), wx_start_time=None, wx_num_hours=24, redo=False


### PR DESCRIPTION
Corrects logic for landfire.py and pyregence.py to make the best choice of LANDFIRE version given the API constraints.

**landfire.py logic:**
The new logic attempts to pick a LANDFIRE version that precedes the fire. For fires in 2016 and earlier, when no preceding LANDFIRE version is available from the API, 2016 is chosen as a best approximation.
In the future, downloaded LANDFIRE archives can be used, but this would not be possible to implement using API.

**pyregence.py logic:**
The new logic attempts to pick a LANDFIRE version that precedes the fire. For fires in 2014 and earlier, when no preceding LANDFIRE version is available from the API, 2014 is chosen as a best approximation.